### PR TITLE
add smno

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,27 +338,31 @@
     map.on('click', function (e) {
 
       // loop through all the layer groups
-      for (var gsLayer in geoJsonLayers) {
+      // for (var gsLayer in geoJsonLayers) {
 
         // loop through all layers of each group
-        geoJsonLayers[gsLayer].eachLayer(function (layer) {
+        geoJsonLayers["polyLayer"].eachLayer(function (layer) {
 
           // get the distance
-          var distance = e.latlng.distanceTo(layer.getLatLng()) / 1000;
+          
+          var distance = e.latlng.distanceTo(layer.getLatLngs()[0][0][0]) / 1000;
 
           // show or hide 
           if (distance <= 10) {
+            console.log(layer.getLatLngs(), distance)
             layer.setStyle({
-              fillOpacity: .8
+              fillOpacity: .4,
+              opacity: 0.8
             });
           } else {
             layer.setStyle({
-              fillOpacity: .1
+              fillOpacity: .1,
+              opacity: .1
             });
           }
 
         });
-      }
+      // }
 
     });
 

--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@
       //   // area2: 'area_sq_m'
       // },
       polyLayer: {
-        source: irelandPoints2,
+        source: irelandPoints4,
         color: '#a9a9a9',
         fillColor: '#3388ff',
         opacity: 1,
@@ -269,6 +269,7 @@
         label: "Archaeological Site Polygons",
         accessor: 'TOWNLAND',
         accessor2: 'EDITED_TYP',
+        attribute3: 'SMNO',
         weight: .5
         // area2: 5
       },
@@ -322,8 +323,12 @@
           return commonStyles;
         },
         onEachFeature: function (feature, layer) {
-          var tooltip =
-            `<b>${feature.properties[layersInfo[gsLayer].accessor]}</b></br>${feature.properties[layersInfo[gsLayer].accessor2]}`;
+          console.log(feature.properties)
+          var tooltip = `<b>${feature.properties[layersInfo[gsLayer].accessor]}</b>
+            </br>${feature.properties[layersInfo[gsLayer].accessor2]}`;
+          if (feature.properties[layersInfo[gsLayer].attribute3]) {
+            tooltip += `<br>SMNO: ${feature.properties[layersInfo[gsLayer].attribute3]}`
+          }
           layer.bindTooltip(tooltip);
         }
       }).addTo(map);


### PR DESCRIPTION
Hey, Will. I changed the poly variable to the one that contains the SMNO attributed. You could also add the site area to the popup. Check out the previous pull request for the marker cluster plugin if you want to use the point layer, too.

The map.on event should highlight polys within 10 km of a click. The `layer.getLatLngs()` method returns an array of coordinates for the polygon. The coordinates are nested 3-deep, so you should use `layer.getLatLngs()[0][0][0]` to get the first coordinate in the first polygon part in a possibly multipart polygon. (E.g., the multiple polys of Hawaii.)